### PR TITLE
add delay field

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,26 @@ Follow the [installation guide](https://docs.n8n.io/integrations/community-nodes
 ## Operations
 
 Only a single operation is supported right now to send a notification.
+
+### Supported Fields
+
+- **Topic**: The ntfy.sh topic to send the notification to (required)
+- **Message**: The notification message content (required)
+- **Title**: Optional notification title
+- **Priority**: Message priority (1-5, where 1=min, 3=default, 5=urgent)
+- **Click URL**: URL to open when notification is clicked
+- **Tags**: Comma-separated tags (can include emoji short codes)
+- **Delay**: Schedule delivery for later (supports multiple formats):
+  - Duration: `30m`, `2h`, `1 day`, `3 days`
+  - Unix timestamp: `1639194738`
+  - Natural language: `10am`, `8:30pm`, `tomorrow, 3pm`, `Tuesday, 7am`
+  - Min delay: 10 seconds, Max delay: 3 days (Max delay can be configured with the message-delay-limit option)
+
+### Additional Fields
+
+- **Alternate ntfy.sh Server URL**: Use a custom ntfy.sh server
+- **Authentication Token**: Bearer token for protected topics
+
 ![alt ntfy sample operation](https://github.com/raghavanand98/n8n-ntfy.sh/blob/master/sample.png?raw=true)
 
 ## Compatibility
@@ -23,9 +43,10 @@ Tested against 0.212.0.
 
 ## Roadmap
 
-
 The broad roadmap is to support all parameters in the [ntfy API](https://docs.ntfy.sh/publish/#publish-as-json). Roughly the order of this will likely be:
+
 - [X] Click
+- [X] Delay (scheduled delivery)
 - [ ] Actions
 - [X] Custom ntfy.sh server support
 - [ ] All other params
@@ -34,4 +55,3 @@ The broad roadmap is to support all parameters in the [ntfy API](https://docs.nt
 - [ ] Improve the security model for the topic name since it's effectively a secret.
 - [ ] Add documentation for local development
 - [ ] Add tests
-

--- a/nodes/ntfy/ntfy.node.ts
+++ b/nodes/ntfy/ntfy.node.ts
@@ -73,6 +73,13 @@ export class Ntfy implements INodeType {
 				default: '',
 			},
 			{
+				displayName: 'Delay',
+				name: 'delay',
+				type: 'string',
+				default: '',
+				description: 'Schedule delivery for later. Use Unix timestamp (1639194738), duration (30m, 3h, 2 days), or natural language (10am, 8:30pm, tomorrow 3pm). Min: 10 seconds, Max: 3 days.',
+			},
+			{
 				displayName: 'Additional Fields',
 				name: 'additional_fields',
 				type: 'collection',
@@ -105,8 +112,11 @@ export class Ntfy implements INodeType {
 			} = {};
 
 
-			for (const field of ['topic', 'message', 'title', 'priority', 'click']) {
-				body[field] = this.getNodeParameter(field, i) as string;
+			for (const field of ['topic', 'message', 'title', 'priority', 'click', 'delay']) {
+				const value = this.getNodeParameter(field, i) as string;
+				if (value) {
+					body[field] = value;
+				}
 			}
 
 			body.tags = this.getNodeParameter('tags', i)?.toString().replace(/\s/, '').split(',');


### PR DESCRIPTION
This PR implements the delay field for scheduled delivery, enabling users to schedule ntfy.sh notifications for future delivery. This feature aligns with the [ntfy.sh scheduled delivery feature](https://docs.ntfy.sh/publish/?h=delay#scheduled-delivery).

Supported Formats:
Duration: 30m, 2h, 1 day, 3 days
Unix Timestamp: 1639194738
Natural Language: 10am, 8:30pm, tomorrow, 3pm, Tuesday, 7am

Constraints:
Minimum Delay: 10 seconds
Maximum Delay: 3 days ([configurable server-side](https://docs.ntfy.sh/config/?h=message+limit+delay#message-limits))